### PR TITLE
fix(orders): cancel integrity — is_cancellable vocab + PATCH-status cancel bypass (#846 slice 2)

### DIFF
--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -67,22 +67,22 @@ class SalesOrder(Base):
     shipping_cost = Column(Numeric(10, 2), nullable=True, default=0.00)
     grand_total = Column(Numeric(10, 2), nullable=False)  # total + tax + shipping
 
-    # Order Status (Customer-Facing)
-    # Lifecycle: draft → pending_payment → confirmed → in_production → ready_to_ship → shipped → delivered → completed
-    # Alternative paths: payment_failed, partially_shipped, on_hold, cancelled
+    # Order Status. The authoritative vocabulary + allowed transitions live in
+    # app/core/status_config.py (SalesOrderStatus / SALES_ORDER_TRANSITIONS);
+    # keep this comment in sync with that enum.
+    # Lifecycle: pending → confirmed → in_production → ready_to_ship → shipped → delivered → completed
     # Status meanings:
+    #   - pending_confirmation: External order awaiting admin review
     #   - draft: Order being created/edited
-    #   - pending_payment: Submitted, awaiting payment
-    #   - payment_failed: Payment declined, needs retry
-    #   - confirmed: Payment received, ready for production planning
+    #   - pending: Created and awaiting confirmation (default for new/quote-converted orders)
+    #   - confirmed: Reviewed/accepted, ready for production planning
     #   - in_production: At least one WO is in progress
-    #   - ready_to_ship: All WOs complete and QC passed, awaiting shipment
-    #   - partially_shipped: Multi-line order with some items shipped
+    #   - ready_to_ship: Production complete, awaiting shipment
     #   - shipped: All items shipped
     #   - delivered: Carrier confirmed delivery
     #   - completed: Order fully closed
-    #   - on_hold: Production/shipment paused
-    #   - cancelled: Order terminated
+    #   - on_hold: Production/shipment paused (alternative path)
+    #   - cancelled: Order terminated (alternative path)
     status = Column(String(50), nullable=False, default="draft", index=True)
 
     # Payment Status

--- a/backend/app/models/sales_order.py
+++ b/backend/app/models/sales_order.py
@@ -170,8 +170,15 @@ class SalesOrder(Base):
 
     @property
     def is_cancellable(self) -> bool:
-        """Check if order can be cancelled"""
-        return self.status in ["pending_confirmation", "draft", "pending_payment", "payment_failed", "confirmed", "on_hold"]
+        """Check if order can be cancelled (pre-fulfillment states).
+
+        Uses the real SalesOrderStatus vocabulary: 'pending' is the status
+        every newly created / quote-converted order gets, so it MUST be here.
+        The former list referenced 'pending_payment'/'payment_failed', which
+        are not valid SalesOrderStatus values, and omitted 'pending' — so the
+        Cancel action 400'd on every brand-new order.
+        """
+        return self.status in ["pending_confirmation", "draft", "pending", "confirmed", "on_hold"]
 
     @property
     def is_paid(self) -> bool:

--- a/backend/app/services/sales_order_service.py
+++ b/backend/app/services/sales_order_service.py
@@ -857,6 +857,21 @@ def update_sales_order_status(
             ),
         )
 
+    # Cancellation must go through cancel_sales_order() so the reason and
+    # cancelled_at are recorded and linked production orders / material
+    # reservations are released. A bare status flip to 'cancelled' skipped the
+    # is_cancellable guard and all cleanup, leaving a terminal order with no
+    # audit trail and orphaned WOs/inventory.
+    if new_status == "cancelled":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Orders cannot be cancelled via status update. Use "
+                "POST /sales-orders/<order_id>/cancel so the reason is recorded "
+                "and production orders / reservations are released."
+            ),
+        )
+
     try:
         validate_sales_order_transition(old_status, new_status)
     except StatusTransitionError as exc:

--- a/backend/tests/api/v1/test_sales_orders.py
+++ b/backend/tests/api/v1/test_sales_orders.py
@@ -558,6 +558,25 @@ class TestUpdateStatus:
         })
         assert response.status_code == 404
 
+    def test_cannot_cancel_via_status_update(self, client, db, make_sales_order, make_product):
+        """PATCH /status to 'cancelled' must be rejected — cancellation has to
+        go through POST /cancel so the reason + cancelled_at are recorded and
+        production orders / reservations are released (wi-005 bypass)."""
+        product = make_product(selling_price=Decimal("10.00"))
+        so = make_sales_order(product_id=product.id, status="confirmed")
+        db.flush()
+
+        response = client.patch(f"{BASE_URL}/{so.id}/status", json={
+            "status": "cancelled",
+        })
+        assert response.status_code == 400
+        assert "cancel" in response.json()["detail"].lower()
+
+        # The order is untouched — no silent terminal cancellation.
+        got = client.get(f"{BASE_URL}/{so.id}").json()
+        assert got["status"] == "confirmed"
+        assert got["cancelled_at"] is None
+
     def test_update_status_with_internal_notes(self, client, db, make_sales_order, make_product):
         product = make_product(selling_price=Decimal("10.00"))
         so = make_sales_order(product_id=product.id, status="pending")
@@ -801,13 +820,15 @@ class TestCancelSalesOrder:
         data = response.json()
         assert data["status"] == "cancelled"
 
-    def test_cancel_pending_payment_order(self, client, db, make_sales_order, make_product):
+    def test_cancel_pending_order(self, client, db, make_sales_order, make_product):
+        """Every newly created order is 'pending' — cancelling it must work
+        (regression: is_cancellable omitted 'pending', so this 400'd)."""
         product = make_product(selling_price=Decimal("10.00"))
-        so = make_sales_order(product_id=product.id, status="pending_payment")
+        so = make_sales_order(product_id=product.id, status="pending")
         db.flush()
 
         response = client.post(f"{BASE_URL}/{so.id}/cancel", json={
-            "cancellation_reason": "Payment issue",
+            "cancellation_reason": "Changed mind",
         })
         assert response.status_code == 200
         assert response.json()["status"] == "cancelled"

--- a/backend/tests/services/test_sales_order_service.py
+++ b/backend/tests/services/test_sales_order_service.py
@@ -1615,10 +1615,16 @@ class TestSalesOrderModelProperties:
         so = make_sales_order(status="in_production")
         assert so.is_cancellable is False
 
-    def test_not_cancellable_for_pending(self, db, make_sales_order):
-        """'pending' is NOT in the cancellable list (it uses 'pending_payment' instead)."""
+    def test_cancellable_for_pending(self, db, make_sales_order):
+        """'pending' — the status every newly created order gets — MUST be
+        cancellable. The old list omitted it (and referenced non-existent
+        'pending_payment'/'payment_failed'), so Cancel 400'd on new orders."""
         so = make_sales_order(status="pending")
-        assert so.is_cancellable is False
+        assert so.is_cancellable is True
+
+    def test_cancellable_for_pending_confirmation(self, db, make_sales_order):
+        so = make_sales_order(status="pending_confirmation")
+        assert so.is_cancellable is True
 
     def test_is_paid(self, db, make_sales_order):
         so = make_sales_order(payment_status="paid")


### PR DESCRIPTION
## Orders audit — slice 2: cancel integrity

Two coupled cancellation bugs, both verified against `main` (O1 was independently found by 5 audit lenses).

### O1 [major] — Cancel Order 400s on every new order
`SalesOrder.is_cancellable` listed **`pending_payment`** and **`payment_failed`** — neither is a valid `SalesOrderStatus` — and **omitted `pending`**, the status every newly created and quote-converted order actually gets. So the Cancel Order button (which the workflow panel shows for pending orders) failed with `400 "Cannot cancel order with status 'pending'"`, and the only workaround was to *confirm* the order first, then cancel it. Corrected to the real pre-fulfillment vocabulary: `pending_confirmation, draft, pending, confirmed, on_hold`.

A backend test literally codified the bug — `test_not_cancellable_for_pending` asserted `pending` is NOT cancellable, commenting "*(it uses pending_payment instead)*". Flipped to assert the correct behavior.

### wi-005 [major] — a second cancellation path that skipped all cleanup
`PATCH /{id}/status` with `{"status": "cancelled"}` bypassed `cancel_sales_order()` entirely: no `cancelled_at`, no reason recorded, and **no release of linked production orders / material reservations** — leaving a terminal order with no audit trail and orphaned WOs + inventory. Now rejected with `400` directing callers to `POST /cancel`, exactly mirroring the existing `"shipped"` guard (#838, which forces shipping through `ship_order` so inventory/COGS post). Cancellation is a side-effectful operation; it belongs to its dedicated endpoint, not a bare status flip.

These are synergistic: O1 makes `POST /cancel` work on pending orders, and wi-005 forces *all* cancellation through that now-correct path.

### Tests
Flipped the stale property test; repointed the phantom-`pending_payment` API test to `pending`; +`pending_confirmation` property test; +wi-005 guard test (PATCH→cancelled returns 400 and the order stays `confirmed` with `cancelled_at` NULL). Full sales-order suites **318/318**, ruff clean.

Next: slice 4 (list + wizard wiring). Slice 3 (billing terms) is pending a product decision on prepay-vs-terms gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sales order cancellation eligibility so orders in additional valid lifecycle states (including `pending` and related states) can be cancelled.
  * Prevented setting a sales order to `cancelled` via the generic status update endpoint; cancellation must use the dedicated cancel action to preserve cancellation details.
  * Updated and added regression tests to verify both blocked transitions to `cancelled` and successful cancellation from `pending`, with correct timestamps/reason handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->