### PR TITLE
fix(mrp): routing op copy flows are idempotent — no more silent append-duplication (904)

### DIFF
--- a/backend/app/services/routing_service.py
+++ b/backend/app/services/routing_service.py
@@ -399,6 +399,19 @@ def apply_template_to_product(
 
     product = get_or_404(db, Product, product_id, "Product not found")
 
+    # #904: serialize concurrent/duplicate "apply template" calls for the
+    # same product. Without this lock, two overlapping requests (double
+    # submit, client retry-after-timeout, two admins editing the same
+    # product) each pass the "existing routing" check below against the
+    # same pre-mutation snapshot and each append their own active operation
+    # set — the second call never sees the first's not-yet-committed
+    # deactivation/insert, so both generations end up active on one
+    # routing. Locking the product row forces the second caller to wait for
+    # the first to commit, then re-read the now-current (post-commit) state
+    # before deciding what to deactivate/replace. Row lock, not a table
+    # lock — concurrent applies for *different* products are unaffected.
+    db.query(Product).filter(Product.id == product.id).with_for_update().first()
+
     existing = (
         db.query(Routing)
         .filter(Routing.product_id == product_id, Routing.is_active.is_(True))

--- a/backend/app/services/variant_service.py
+++ b/backend/app/services/variant_service.py
@@ -446,7 +446,17 @@ def sync_routing_to_variants(db: Session, template_id: int) -> dict:
         op.id: list(op.materials) for op in template_ops
     }
 
-    variants = db.query(Product).filter(Product.parent_product_id == template_id).all()
+    # Deterministic order matters now that each iteration takes a row lock
+    # (#904 fix below) — two concurrent sync calls must always acquire
+    # per-variant locks in the same order, or they can deadlock each other
+    # (classic lock-ordering deadlock: call A locks variant 1 then waits on
+    # variant 2 while call B locks variant 2 then waits on variant 1).
+    variants = (
+        db.query(Product)
+        .filter(Product.parent_product_id == template_id)
+        .order_by(Product.id)
+        .all()
+    )
 
     synced = 0
     errors = []
@@ -454,6 +464,16 @@ def sync_routing_to_variants(db: Session, template_id: int) -> dict:
     for variant in variants:
         savepoint = db.begin_nested()
         try:
+            # #904: serialize concurrent/duplicate "sync routing to variants"
+            # calls for the same variant. Same failure mode as
+            # apply_template_to_product — without this lock, two overlapping
+            # sync calls each pass the "get or create variant routing" check
+            # against the same pre-mutation snapshot, and the second call's
+            # `variant_routing.operations = []` clear doesn't see the
+            # first's not-yet-committed inserts, so both re-copies end up
+            # active on one routing. Row lock, not a table lock.
+            db.query(Product).filter(Product.id == variant.id).with_for_update().first()
+
             # Resolve this variant's target material from stored metadata
             meta = variant.variant_metadata or {}
             mat_type_id = meta.get("material_type_id")

--- a/backend/tests/api/v1/test_routings.py
+++ b/backend/tests/api/v1/test_routings.py
@@ -734,13 +734,17 @@ class TestApplyTemplateIdempotency:
         POST /apply-template). Uses two independent, really-committing
         sessions (the transactional `db`/`client` fixtures share a single
         connection and can't model real concurrency) synchronized with a
-        barrier so both threads read the same pre-mutation state before
-        either mutates, then runs them for real via threading.
+        barrier planted at the actual check-then-act boundary (the SQL read
+        of the existing routing, immediately before the deactivate
+        mutation) rather than at the earlier Product lookup — see the
+        comment block at the barrier definition for why placement matters
+        and how the FOR UPDATE fix changes which worker ever reaches it.
         """
-        from app.db.session import SessionLocal
+        from sqlalchemy import event
+
+        from app.db.session import SessionLocal, engine
         from app.models.manufacturing import Routing, RoutingOperation
         from app.models.product import Product
-        from app.core import utils as core_utils
         from app.services import routing_service as rs
 
         setup_db = SessionLocal()
@@ -789,17 +793,56 @@ class TestApplyTemplateIdempotency:
             finally:
                 db1.close()
 
-            # Race: two overlapping "apply template again" calls, synchronized
-            # to both pass the product lookup (no lock taken yet) before
-            # either proceeds to check-and-mutate the routing.
-            barrier = threading.Barrier(2, timeout=15)
-            orig_get_or_404 = core_utils.get_or_404
+            # Race: two overlapping "apply template again" calls.
+            #
+            # SYNCHRONIZATION POINT: the barrier fires on the SQL that reads
+            # the *existing* active routing for this product — the
+            # check-then-act read, immediately before the "deactivate old
+            # ops" mutation. This is deliberately NOT the earlier Product
+            # lookup: a barrier planted before the #904 FOR UPDATE row lock
+            # only guarantees both threads *start* together, and then lets
+            # the OS scheduler decide how far each gets before the other is
+            # scheduled again. One worker can legitimately run all the way
+            # through read -> deactivate -> insert -> commit before the
+            # other thread is even scheduled, which would let a broken
+            # (unlocked) implementation pass this test by luck rather than
+            # by having its race genuinely exercised. Hooking the SQL
+            # emission for the "existing routing" read (via
+            # before_cursor_execute, matched by table + absence of the
+            # is_template filter that's unique to the earlier template
+            # lookup) forces both threads to reach the actual vulnerable
+            # window together.
+            #
+            # CRITICAL SUBTLETY: with the #904 FOR UPDATE fix in place, the
+            # second worker blocks *at the row lock itself* — a statement
+            # that runs BEFORE the one this barrier watches — while the
+            # first worker holds it through its whole transaction. So under
+            # FIXED code the second worker can never reach this barrier
+            # while the first is still inside its transaction: the first
+            # worker's barrier.wait() times out / raises
+            # BrokenBarrierError (expected — the assertions below, not the
+            # barrier, are the real oracle), the first worker proceeds and
+            # commits, the lock releases, and only then does the second
+            # worker reach its own (now-broken, so non-blocking) barrier
+            # call and run serialized against the first's already-committed
+            # state. Under UNFIXED (unlocked) code there's no lock to
+            # stall on, so both workers reach the barrier together, both
+            # proceed to deactivate+insert concurrently, and the final
+            # active-op-count assertion below catches the duplication.
+            barrier = threading.Barrier(2)
+            thread_state = threading.local()
 
-            def synced_get_or_404(db, model, id, detail=None):
-                result = orig_get_or_404(db, model, id, detail)
-                if model is Product:
-                    barrier.wait()
-                return result
+            def sync_on_existing_routing_read(conn, cursor, statement, parameters, context, executemany):
+                upper = statement.upper()
+                if "ROUTINGS" not in upper or "IS_TEMPLATE" in upper:
+                    return
+                if getattr(thread_state, "fired", False):
+                    return
+                thread_state.fired = True
+                try:
+                    barrier.wait(timeout=5)
+                except threading.BrokenBarrierError:
+                    pass  # expected under FIXED code — see comment block above
 
             errors = []
 
@@ -814,7 +857,7 @@ class TestApplyTemplateIdempotency:
                 finally:
                     db.close()
 
-            rs.get_or_404 = synced_get_or_404
+            event.listen(engine, "before_cursor_execute", sync_on_existing_routing_read)
             try:
                 t1 = threading.Thread(target=worker)
                 t2 = threading.Thread(target=worker)
@@ -823,8 +866,10 @@ class TestApplyTemplateIdempotency:
                 t1.join(timeout=30)
                 t2.join(timeout=30)
             finally:
-                rs.get_or_404 = orig_get_or_404
+                event.remove(engine, "before_cursor_execute", sync_on_existing_routing_read)
 
+            assert not t1.is_alive(), "worker thread 1 did not complete within timeout (hung)"
+            assert not t2.is_alive(), "worker thread 2 did not complete within timeout (hung)"
             assert not errors, f"apply_template_to_product raised under race: {errors}"
 
             verify_db = SessionLocal()

--- a/backend/tests/api/v1/test_routings.py
+++ b/backend/tests/api/v1/test_routings.py
@@ -10,6 +10,7 @@ Covers:
 - Authentication requirements for write endpoints
 - 404 and 422 error handling
 """
+import threading
 import pytest
 from decimal import Decimal
 
@@ -643,6 +644,223 @@ class TestApplyTemplate:
     def test_apply_template_missing_fields_returns_422(self, client):
         response = client.post(f"{BASE_URL}/apply-template", json={})
         assert response.status_code == 422
+
+
+class TestApplyTemplateIdempotency:
+    """Regression coverage for #904 — apply-template must never silently
+    append a second generation of operations onto an already-populated
+    routing. Root cause: apply_template_to_product's "does this product
+    already have an active routing?" check-then-act (deactivate old ops,
+    then insert new ones) was not atomic, so two overlapping calls for the
+    same product could each pass the check against the same pre-mutation
+    state and each insert their own active operation set — reproducing the
+    exact COMP-005 data shape (two interleaved active generations on one
+    routing; see #904 and the #876 classifier session).
+    """
+
+    def test_repeated_apply_template_does_not_double_active_ops(self, client, make_product):
+        """Applying the same template twice must leave the active op count
+        unchanged (replace semantics), not doubled."""
+        product = make_product(item_type="finished_good", procurement_type="make")
+
+        template = _create_routing(
+            client, is_template=True, code="TPL-IDEMPOTENT", name="Idempotent Template",
+        )
+        _create_operation(
+            client, template["id"], operation_code="PRINT", operation_name="3D Print",
+            sequence=10, run_time_minutes="60.0",
+        )
+        _create_operation(
+            client, template["id"], operation_code="QC", operation_name="QC",
+            sequence=20, run_time_minutes="2.0",
+        )
+
+        r1 = client.post(f"{BASE_URL}/apply-template", json={
+            "template_id": template["id"], "product_id": product.id,
+        })
+        assert r1.status_code == 200, r1.text
+        assert len(r1.json()["operations"]) == 2
+
+        r2 = client.post(f"{BASE_URL}/apply-template", json={
+            "template_id": template["id"], "product_id": product.id,
+        })
+        assert r2.status_code == 200, r2.text
+        assert len(r2.json()["operations"]) == 2
+
+        routing_id = r2.json()["routing_id"]
+        active_ops = client.get(f"{BASE_URL}/{routing_id}/operations").json()
+        assert len(active_ops) == 2, (
+            f"expected 2 active ops after repeated apply-template, got {len(active_ops)}"
+        )
+
+    def test_apply_template_replaces_manually_built_operations(self, client, make_product):
+        """Applying a template onto a routing that already has operations
+        (built by any other origin — manual add, an older process, etc.)
+        must deactivate the old ones, not leave them active alongside the
+        new set."""
+        product = make_product(item_type="finished_good", procurement_type="make")
+
+        routing = _create_routing(client, product_id=product.id)
+        _create_operation(client, routing["id"], operation_code="QC", operation_name="QC", sequence=1)
+        _create_operation(client, routing["id"], operation_code="PRINT", operation_name="3D Print", sequence=2)
+
+        template = _create_routing(
+            client, is_template=True, code="TPL-REPLACE", name="Replace Template",
+        )
+        _create_operation(
+            client, template["id"], operation_code="PRINT", operation_name="3D Print",
+            run_time_minutes="60.0",
+        )
+        _create_operation(
+            client, template["id"], operation_code="ASSEMBLE", operation_name="Assembly",
+            sequence=20, run_time_minutes="5.0",
+        )
+
+        response = client.post(f"{BASE_URL}/apply-template", json={
+            "template_id": template["id"], "product_id": product.id,
+        })
+        assert response.status_code == 200, response.text
+
+        active_ops = client.get(f"{BASE_URL}/{routing['id']}/operations").json()
+        assert len(active_ops) == 2, (
+            f"expected the manually-built ops to be replaced (2 active), got {len(active_ops)}"
+        )
+        assert {op["operation_code"] for op in active_ops} == {"PRINT", "ASSEMBLE"}
+
+    def test_apply_template_concurrent_double_submit_no_duplicate_active_ops(self):
+        """Two overlapping 'apply template' calls for the same product must
+        not both leave their operation set active — this is the literal
+        #904 reproduction (double-click / retry-after-timeout on
+        POST /apply-template). Uses two independent, really-committing
+        sessions (the transactional `db`/`client` fixtures share a single
+        connection and can't model real concurrency) synchronized with a
+        barrier so both threads read the same pre-mutation state before
+        either mutates, then runs them for real via threading.
+        """
+        from app.db.session import SessionLocal
+        from app.models.manufacturing import Routing, RoutingOperation
+        from app.models.product import Product
+        from app.core import utils as core_utils
+        from app.services import routing_service as rs
+
+        setup_db = SessionLocal()
+        try:
+            product = Product(
+                sku="TEST-904-RACE-PROD", name="904 Race Product",
+                item_type="finished_good", procurement_type="make", unit="EA",
+                active=True,
+            )
+            setup_db.add(product)
+            setup_db.flush()
+
+            template = Routing(
+                code="TPL-904-RACE", name="904 Race Template", is_template=True,
+                version=1, revision="1.0", is_active=True,
+            )
+            setup_db.add(template)
+            setup_db.flush()
+
+            setup_db.add_all([
+                RoutingOperation(
+                    routing_id=template.id, work_center_id=1, sequence=10,
+                    operation_code="PRINT", operation_name="3D Print",
+                    run_time_minutes=Decimal("60"), setup_time_minutes=Decimal("0"),
+                ),
+                RoutingOperation(
+                    routing_id=template.id, work_center_id=1, sequence=20,
+                    operation_code="QC", operation_name="QC",
+                    run_time_minutes=Decimal("2"), setup_time_minutes=Decimal("0"),
+                ),
+            ])
+            setup_db.flush()
+            setup_db.commit()
+
+            product_id = product.id
+            template_id = template.id
+        finally:
+            setup_db.close()
+
+        try:
+            # Generation 1 — establishes the "already has an active routing"
+            # precondition the race needs (non-racy, sequential call).
+            db1 = SessionLocal()
+            try:
+                rs.apply_template_to_product(db1, template_id=template_id, product_id=product_id)
+            finally:
+                db1.close()
+
+            # Race: two overlapping "apply template again" calls, synchronized
+            # to both pass the product lookup (no lock taken yet) before
+            # either proceeds to check-and-mutate the routing.
+            barrier = threading.Barrier(2, timeout=15)
+            orig_get_or_404 = core_utils.get_or_404
+
+            def synced_get_or_404(db, model, id, detail=None):
+                result = orig_get_or_404(db, model, id, detail)
+                if model is Product:
+                    barrier.wait()
+                return result
+
+            errors = []
+
+            def worker():
+                db = SessionLocal()
+                try:
+                    rs.apply_template_to_product(
+                        db, template_id=template_id, product_id=product_id,
+                    )
+                except Exception as e:  # noqa: BLE001
+                    errors.append(repr(e))
+                finally:
+                    db.close()
+
+            rs.get_or_404 = synced_get_or_404
+            try:
+                t1 = threading.Thread(target=worker)
+                t2 = threading.Thread(target=worker)
+                t1.start()
+                t2.start()
+                t1.join(timeout=30)
+                t2.join(timeout=30)
+            finally:
+                rs.get_or_404 = orig_get_or_404
+
+            assert not errors, f"apply_template_to_product raised under race: {errors}"
+
+            verify_db = SessionLocal()
+            try:
+                routing = verify_db.query(Routing).filter(
+                    Routing.product_id == product_id, Routing.is_active.is_(True)
+                ).first()
+                active_ops = verify_db.query(RoutingOperation).filter(
+                    RoutingOperation.routing_id == routing.id,
+                    RoutingOperation.is_active.is_(True),
+                ).count()
+                assert active_ops == 2, (
+                    f"expected 2 active ops after concurrent double-submit, got {active_ops} "
+                    f"(#904 regression: two generations left active)"
+                )
+            finally:
+                verify_db.close()
+        finally:
+            cleanup_db = SessionLocal()
+            try:
+                routing_ids = [
+                    r.id for r in cleanup_db.query(Routing).filter(
+                        (Routing.product_id == product_id) | (Routing.id == template_id)
+                    ).all()
+                ]
+                if routing_ids:
+                    cleanup_db.query(RoutingOperation).filter(
+                        RoutingOperation.routing_id.in_(routing_ids)
+                    ).delete(synchronize_session=False)
+                    cleanup_db.query(Routing).filter(
+                        Routing.id.in_(routing_ids)
+                    ).delete(synchronize_session=False)
+                cleanup_db.query(Product).filter(Product.id == product_id).delete(synchronize_session=False)
+                cleanup_db.commit()
+            finally:
+                cleanup_db.close()
 
 
 # =============================================================================

--- a/backend/tests/test_variant_service.py
+++ b/backend/tests/test_variant_service.py
@@ -477,12 +477,19 @@ class TestSyncRoutingToVariants:
         """Two overlapping sync-routing-to-variants calls for the same
         template/variant must not both leave their re-copied operation set
         active — the #904 reproduction for the variant-copy flow. Uses two
-        independent, really-committing sessions synchronized with a
-        barrier (the transactional `db` fixture shares one connection and
-        can't model real concurrency)."""
+        independent, really-committing sessions (the transactional `db`
+        fixture shares one connection and can't model real concurrency)
+        synchronized with a barrier planted at the actual check-then-act
+        boundary (the SQL read of the variant's existing routing,
+        immediately before the operations-clear mutation) rather than at
+        the earlier template lookup — see the comment block at the barrier
+        definition for why placement matters and how the FOR UPDATE fix
+        changes which worker ever reaches it."""
         import threading
 
-        from app.db.session import SessionLocal
+        from sqlalchemy import event
+
+        from app.db.session import SessionLocal, engine
         from app.models.manufacturing import Routing as _Routing, RoutingOperation as _RoutingOperation
         from app.models.product import Product
         from app.models.work_center import WorkCenter
@@ -538,14 +545,53 @@ class TestSyncRoutingToVariants:
             finally:
                 db1.close()
 
-            barrier = threading.Barrier(2, timeout=15)
-            orig_get_item = vs.get_item
+            # SYNCHRONIZATION POINT: the barrier fires on the SQL that reads
+            # the variant's *existing* active routing — the check-then-act
+            # read, immediately before the "clear operations" mutation
+            # (`variant_routing.operations = []`). This is deliberately NOT
+            # the earlier `get_item(template_id)` lookup: a barrier planted
+            # that early only guarantees both threads *start* together,
+            # then lets the scheduler decide how far each runs before the
+            # other resumes. One worker can legitimately finish its entire
+            # read -> clear -> re-copy -> commit before the other thread is
+            # even scheduled, letting a broken (unlocked) implementation
+            # pass this test by luck instead of by having its race
+            # genuinely exercised. Hooking the SQL emission for the
+            # "variant's existing routing" read (via before_cursor_execute,
+            # matched by table + absence of the ORDER BY that's unique to
+            # the earlier template-routing lookup) forces both threads to
+            # reach the actual vulnerable window together.
+            #
+            # CRITICAL SUBTLETY: with the #904 FOR UPDATE fix in place, the
+            # second worker blocks *at the row lock itself* — a statement
+            # that runs BEFORE the one this barrier watches — while the
+            # first worker holds it through its whole transaction. So under
+            # FIXED code the second worker can never reach this barrier
+            # while the first is still inside its transaction: the first
+            # worker's barrier.wait() times out / raises
+            # BrokenBarrierError (expected — the assertions below, not the
+            # barrier, are the real oracle), the first worker proceeds and
+            # commits, the lock releases, and only then does the second
+            # worker reach its own (now-broken, so non-blocking) barrier
+            # call and run serialized against the first's already-committed
+            # state. Under UNFIXED (unlocked) code there's no lock to stall
+            # on, so both workers reach the barrier together, both proceed
+            # to clear+re-copy concurrently, and the final active-op-count
+            # assertion below catches the duplication.
+            barrier = threading.Barrier(2)
+            thread_state = threading.local()
 
-            def synced_get_item(db, item_id):
-                result = orig_get_item(db, item_id)
-                if item_id == template_id:
-                    barrier.wait()
-                return result
+            def sync_on_variant_routing_read(conn, cursor, statement, parameters, context, executemany):
+                upper = statement.upper()
+                if "ROUTINGS" not in upper or "ORDER BY" in upper:
+                    return
+                if getattr(thread_state, "fired", False):
+                    return
+                thread_state.fired = True
+                try:
+                    barrier.wait(timeout=5)
+                except threading.BrokenBarrierError:
+                    pass  # expected under FIXED code — see comment block above
 
             errors = []
 
@@ -558,7 +604,7 @@ class TestSyncRoutingToVariants:
                 finally:
                     db.close()
 
-            vs.get_item = synced_get_item
+            event.listen(engine, "before_cursor_execute", sync_on_variant_routing_read)
             try:
                 t1 = threading.Thread(target=worker)
                 t2 = threading.Thread(target=worker)
@@ -567,8 +613,10 @@ class TestSyncRoutingToVariants:
                 t1.join(timeout=30)
                 t2.join(timeout=30)
             finally:
-                vs.get_item = orig_get_item
+                event.remove(engine, "before_cursor_execute", sync_on_variant_routing_read)
 
+            assert not t1.is_alive(), "worker thread 1 did not complete within timeout (hung)"
+            assert not t2.is_alive(), "worker thread 2 did not complete within timeout (hung)"
             assert not errors, f"sync_routing_to_variants raised under race: {errors}"
 
             verify_db = SessionLocal()

--- a/backend/tests/test_variant_service.py
+++ b/backend/tests/test_variant_service.py
@@ -429,3 +429,180 @@ class TestListItemsExcludesVariants:
 
         assert "FG-TEST-TMPL" in skus
         assert "FG-TEST-TMPL-PLA_BASIC-BLU" in skus
+
+
+class TestSyncRoutingToVariants:
+    """Regression coverage for #904 — sync-routing-to-variants must never
+    silently append a second generation of operations onto an
+    already-populated variant routing. Same failure class as
+    apply_template_to_product: the "get or create variant routing" +
+    "clear + re-copy from template" sequence was a non-atomic
+    check-then-act, so two overlapping sync calls for the same variant
+    could each pass the check against the same pre-mutation state and
+    each leave their own re-copied operation set active.
+    """
+
+    def test_repeated_sync_does_not_double_active_ops(
+        self, db, template_product, material_type_pla, color_blue,
+        material_color_blue, filament_blue,
+    ):
+        """Syncing the same template to variants twice must leave each
+        variant's active op count unchanged (replace semantics)."""
+        result = variant_service.create_variant(
+            db, template_product.id, material_type_pla.id, color_blue.id,
+        )
+        variant_routing = (
+            db.query(Routing)
+            .filter(Routing.product_id == result["id"], Routing.is_active.is_(True))
+            .first()
+        )
+
+        r1 = variant_service.sync_routing_to_variants(db, template_product.id)
+        assert r1["synced"] == 1
+        ops_after_1 = db.query(RoutingOperation).filter(
+            RoutingOperation.routing_id == variant_routing.id
+        ).all()
+        assert len(ops_after_1) == 1
+
+        r2 = variant_service.sync_routing_to_variants(db, template_product.id)
+        assert r2["synced"] == 1
+        ops_after_2 = db.query(RoutingOperation).filter(
+            RoutingOperation.routing_id == variant_routing.id
+        ).all()
+        assert len(ops_after_2) == 1, (
+            f"expected 1 op on the variant routing after repeated sync, got {len(ops_after_2)}"
+        )
+
+    def test_sync_concurrent_double_submit_no_duplicate_active_ops(self):
+        """Two overlapping sync-routing-to-variants calls for the same
+        template/variant must not both leave their re-copied operation set
+        active — the #904 reproduction for the variant-copy flow. Uses two
+        independent, really-committing sessions synchronized with a
+        barrier (the transactional `db` fixture shares one connection and
+        can't model real concurrency)."""
+        import threading
+
+        from app.db.session import SessionLocal
+        from app.models.manufacturing import Routing as _Routing, RoutingOperation as _RoutingOperation
+        from app.models.product import Product
+        from app.models.work_center import WorkCenter
+        from app.services import variant_service as vs
+
+        setup_db = SessionLocal()
+        try:
+            wc = WorkCenter(code="TEST-904-SYNC-WC", name="904 Sync WC", is_active=True)
+            setup_db.add(wc)
+            setup_db.flush()
+
+            template = Product(
+                sku="TEST-904-SYNC-TMPL", name="904 Sync Template",
+                item_type="finished_good", procurement_type="make", unit="EA",
+                active=True, is_template=True,
+            )
+            variant = Product(
+                sku="TEST-904-SYNC-VARIANT", name="904 Sync Variant",
+                item_type="finished_good", procurement_type="make", unit="EA",
+                active=True,
+            )
+            setup_db.add_all([template, wc])
+            setup_db.flush()
+            variant.parent_product_id = template.id
+            setup_db.add(variant)
+            setup_db.flush()
+
+            template_routing = _Routing(
+                product_id=template.id, code="RTG-904-SYNC-TMPL", name="904 sync tmpl routing",
+                is_active=True, version=1, revision="1.0",
+            )
+            setup_db.add(template_routing)
+            setup_db.flush()
+            setup_db.add(_RoutingOperation(
+                routing_id=template_routing.id, work_center_id=wc.id, sequence=10,
+                operation_code="PRINT", operation_name="3D Print",
+                run_time_minutes=Decimal("60"), setup_time_minutes=Decimal("0"),
+            ))
+            setup_db.flush()
+            setup_db.commit()
+
+            template_id = template.id
+            variant_id = variant.id
+        finally:
+            setup_db.close()
+
+        try:
+            # Generation 1 on the variant — establishes the "already has an
+            # active routing" precondition the race needs.
+            db1 = SessionLocal()
+            try:
+                vs.sync_routing_to_variants(db1, template_id)
+            finally:
+                db1.close()
+
+            barrier = threading.Barrier(2, timeout=15)
+            orig_get_item = vs.get_item
+
+            def synced_get_item(db, item_id):
+                result = orig_get_item(db, item_id)
+                if item_id == template_id:
+                    barrier.wait()
+                return result
+
+            errors = []
+
+            def worker():
+                db = SessionLocal()
+                try:
+                    vs.sync_routing_to_variants(db, template_id)
+                except Exception as e:  # noqa: BLE001
+                    errors.append(repr(e))
+                finally:
+                    db.close()
+
+            vs.get_item = synced_get_item
+            try:
+                t1 = threading.Thread(target=worker)
+                t2 = threading.Thread(target=worker)
+                t1.start()
+                t2.start()
+                t1.join(timeout=30)
+                t2.join(timeout=30)
+            finally:
+                vs.get_item = orig_get_item
+
+            assert not errors, f"sync_routing_to_variants raised under race: {errors}"
+
+            verify_db = SessionLocal()
+            try:
+                variant_routing = verify_db.query(_Routing).filter(
+                    _Routing.product_id == variant_id, _Routing.is_active.is_(True)
+                ).first()
+                active_ops = verify_db.query(_RoutingOperation).filter(
+                    _RoutingOperation.routing_id == variant_routing.id,
+                    _RoutingOperation.is_active.is_(True),
+                ).count()
+                assert active_ops == 1, (
+                    f"expected 1 active op after concurrent double-submit, got {active_ops} "
+                    f"(#904 regression: two generations left active)"
+                )
+            finally:
+                verify_db.close()
+        finally:
+            cleanup_db = SessionLocal()
+            try:
+                routing_ids = [
+                    r.id for r in cleanup_db.query(_Routing).filter(
+                        _Routing.product_id.in_([template_id, variant_id])
+                    ).all()
+                ]
+                if routing_ids:
+                    cleanup_db.query(_RoutingOperation).filter(
+                        _RoutingOperation.routing_id.in_(routing_ids)
+                    ).delete(synchronize_session=False)
+                    cleanup_db.query(_Routing).filter(
+                        _Routing.id.in_(routing_ids)
+                    ).delete(synchronize_session=False)
+                cleanup_db.query(Product).filter(Product.id.in_([template_id, variant_id])).delete(synchronize_session=False)
+                cleanup_db.query(WorkCenter).filter(WorkCenter.code == "TEST-904-SYNC-WC").delete(synchronize_session=False)
+                cleanup_db.commit()
+            finally:
+                cleanup_db.close()


### PR DESCRIPTION
## Root cause

`apply_template_to_product` and `sync_routing_to_variants` each use a **non-atomic check-then-act**: "does this routing/variant already have operations? deactivate them, then insert the new set" — with no row lock. Two overlapping calls for the same product/variant (double-submit, client retry-after-timeout, two admins editing the same product at once) can each pass the "existing" check against the same pre-mutation snapshot and each insert their own active operation set — the second caller never sees the first's not-yet-committed deactivation/insert.

This was **confirmed empirically**, not just by code reading: a threaded two-session repro (real, independently-committing DB sessions + a `threading.Barrier` synchronizing both callers past the initial lookup before either mutates) showed the *unfixed* code leaving **4 active ops on one routing** after two overlapping "apply template again" calls on a routing that started with 2 — the exact COMP-005 shape (two interleaved active generations on one `routing_id`; see the #876 classifier session comment on this issue).

## Investigation — all four named flows

| Flow | Verdict |
|---|---|
| `routing_service.apply_template_to_product` | **Root cause.** Confirmed vulnerable via the threaded race above. Sequential re-invocation was already correct (verified empirically) — the bug only manifests under overlapping/concurrent calls. |
| `variant_service.sync_routing_to_variants` | Same non-atomic check-then-clear-then-recopy shape, no lock. Fixed by analogy; covered by an equivalent threaded race test (also confirmed vulnerable pre-fix, closed post-fix). This is the propagation vector that faithfully spread the corrupted template routing into all 9 COMP-005 color variants — but it doesn't originate corruption on its own, since sequential calls (and even single-call-onto-populated-routing) were already correct. |
| `item_duplicate_service.duplicate_item` | Ruled out. Always creates a brand-new `Routing` row on a brand-new `Product`; SKU uniqueness is enforced before any routing/BOM copy runs, so it can never touch an already-populated routing. |
| filaops-pro intake `/sku` and `/assembly` | Ruled out. Traced across the **entire git history** of `routes/intake.py` (from the original Phase-1 commit through main) — every version enforces hard SKU uniqueness (409/400) before creating a brand-new `Product` + `Routing`. There is no code path, past or present, where intake looks up or mutates an existing product's routing. |

## Fix

`SELECT ... FOR UPDATE` on the product row before the existing-routing check in both flows, serializing concurrent/duplicate calls so the second caller blocks until the first commits, then re-reads the now-current (post-commit) state before deciding what to deactivate/replace. This is a row lock, not a table lock — concurrent applies for *different* products/variants are unaffected.

`sync_routing_to_variants` also gets a deterministic per-variant lock order (`ORDER BY id`) — without it, two concurrent sync calls that happen to process variants in different orders could deadlock each other (call A locks variant 1 then waits on variant 2 while call B locks variant 2 then waits on variant 1).

Chosen semantics: **replace, not refuse.** Both flows already intended "replace" semantics (deactivate-old, insert-new) for a routing/variant that already has operations — the bug was that this replacement wasn't atomic, not that the semantics were wrong. So the fix makes the existing replace-intent atomic rather than switching to a 409. `item_duplicate_service` and intake needed no change since they already refuse (409/400 on duplicate SKU) before ever touching routing state.

`copy_routing_to_operations` (routing → PO snapshot, append-by-design at release) was left untouched per the task brief.

## Tests

- Sequential idempotency: repeated call → same active op count (both flows)
- Replace-not-append onto a routing/variant-routing that already has operations from another origin
- **Threaded concurrent-double-submit repros for both flows** — fail (op count doubles) on the pre-fix code, pass on the fix. Uses two independent, really-committing `SessionLocal()` sessions (the transactional `db`/`client` test fixture shares one connection and can't model real concurrency) synchronized with a `threading.Barrier` at the pre-lock lookup point.

Full relevant suites green: **367 passed** — `tests/api/v1/test_routings.py`, `tests/test_variant_service.py`, `tests/test_duplicate_item.py`, `tests/services/test_operation_type_catalog.py`, `tests/services/test_small_services.py`. Ruff clean on both changed service files (`app/services/routing_service.py`, `app/services/variant_service.py`).

Note: a full-suite run surfaced 20 pre-existing, unrelated failures in `test_admin_orders.py`/`test_order_import_service.py` (a `sales_orders.unit_price` NOT NULL violation) — confirmed via `git stash` to fail identically on unmodified `main`, nothing to do with this change.

Refs #904, the #876 classifier session (COMP-005 data cleanup), #572 (variant axis work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate active routings when applying the same template repeatedly or concurrently.
  * Ensured template application replaces any existing active routing operations rather than accumulating them.
  * Prevented duplicate routing operations during concurrent variant routing sync.
* **Tests**
  * Added idempotency and replacement regression coverage for `apply-template`.
  * Added concurrency regression tests for both template application and variant routing synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->