### PR TITLE
fix(invoices): void row-lock + decoupled FK guard (894 PR-A follow-up, CodeRabbit round-2)

### DIFF
--- a/backend/app/services/invoice_service.py
+++ b/backend/app/services/invoice_service.py
@@ -473,12 +473,23 @@ def void_invoice(
     (``source_type='invoice_void'``, idempotent). A draft invoice with no
     posted JE is a status-only void — no JE. Sets status='voided',
     voided_at, voided_by_id, void_reason. Commits.
+
+    Concurrency: the invoice is read under a row-level lock (SELECT … FOR
+    UPDATE, same idiom as ``_reconcile_invoice`` in payment_service) so two
+    concurrent voids serialize — the second waits on the lock, re-reads
+    status='voided', and lands on the 400 path instead of double-posting the
+    ``invoice_void`` reversal.
     """
     reason = (reason or "").strip()
     if not reason:
         raise HTTPException(status_code=422, detail="Void reason is required")
 
-    invoice = db.query(Invoice).filter(Invoice.id == invoice_id).first()
+    invoice = (
+        db.query(Invoice)
+        .filter(Invoice.id == invoice_id)
+        .with_for_update()
+        .first()
+    )
     if not invoice:
         raise HTTPException(status_code=404, detail="Invoice not found")
 

--- a/backend/migrations/versions/102_invoice_void_audit.py
+++ b/backend/migrations/versions/102_invoice_void_audit.py
@@ -52,14 +52,16 @@ def upgrade() -> None:
             "invoices",
             sa.Column("voided_by_id", sa.Integer(), nullable=True),
         )
-        if not _has_fk("invoices", "fk_invoices_voided_by_id_users"):
-            op.create_foreign_key(
-                "fk_invoices_voided_by_id_users",
-                "invoices",
-                "users",
-                ["voided_by_id"],
-                ["id"],
-            )
+    # FK guard runs independently of the column-add branch so a brownfield DB
+    # that already has the column but is missing the FK gets healed on rerun.
+    if not _has_fk("invoices", "fk_invoices_voided_by_id_users"):
+        op.create_foreign_key(
+            "fk_invoices_voided_by_id_users",
+            "invoices",
+            "users",
+            ["voided_by_id"],
+            ["id"],
+        )
     if not _has_column("invoices", "void_reason"):
         op.add_column(
             "invoices",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -388,6 +388,22 @@ def setup_database():
         conn.execute(text(
             "ALTER TABLE invoices ADD COLUMN IF NOT EXISTS void_reason VARCHAR(255)"
         ))
+        # FK backfill so the accumulated test DB matches a fresh migration-102
+        # DB (same pg_constraint-guarded pattern as the other FK patches here).
+        conn.execute(text("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'fk_invoices_voided_by_id_users'
+                ) THEN
+                    ALTER TABLE invoices
+                    ADD CONSTRAINT fk_invoices_voided_by_id_users
+                    FOREIGN KEY (voided_by_id) REFERENCES users(id);
+                END IF;
+            END
+            $$;
+        """))
         conn.commit()
 
     # Seed required data

--- a/backend/tests/test_invoice_service.py
+++ b/backend/tests/test_invoice_service.py
@@ -836,3 +836,127 @@ class TestVoidInvoiceAPI:
             f"/api/v1/invoices/{invoice_id}", json={"status": "sent"}
         )
         assert resp.status_code == 422
+
+
+class TestVoidInvoiceConcurrency:
+    """Two concurrent voids must produce exactly one invoice_void reversal.
+
+    Same threaded two-session + Barrier pattern as the #904/PR #907 routing
+    idempotency race tests: real sessions (no savepoint fixture — each worker
+    needs its own connection so the row lock actually contends), a
+    before_cursor_execute hook that parks both workers at a barrier right
+    before the invoice SELECT executes, then assertions on the committed end
+    state. Under the FIXED code (SELECT … FOR UPDATE in void_invoice) the
+    first worker takes the row lock, voids, and commits; the second blocks on
+    the lock, re-reads status='voided', and raises 400. Under UNFIXED
+    (unlocked) code both workers pass the guards together and each posts an
+    invoice_void reversal — the JE-count assertion below catches it.
+    """
+
+    def test_concurrent_void_posts_single_reversal(self):
+        import threading
+
+        from fastapi import HTTPException
+        from sqlalchemy import event
+
+        from app.db.session import SessionLocal, engine
+        from app.models.accounting import GLJournalEntry
+        from app.models.sales_order import SalesOrder
+        from app.services.invoice_service import (
+            create_invoice,
+            mark_sent,
+            void_invoice,
+        )
+
+        # -- Setup with a REAL committed session (visible to both workers) --
+        setup = SessionLocal()
+        try:
+            so = SalesOrder(
+                order_number=f"SO-VOIDRACE-{uuid.uuid4().hex[:8]}",
+                user_id=1,
+                product_id=None,
+                product_name="Void race order",
+                quantity=1,
+                material_type="PLA",
+                unit_price=Decimal("30.00"),
+                total_price=Decimal("30.00"),
+                grand_total=Decimal("30.00"),
+                status="confirmed",
+            )
+            setup.add(so)
+            setup.commit()
+            invoice = create_invoice(setup, so.id)  # commits
+            mark_sent(setup, invoice.id)  # commits + posts the receivable JE
+            invoice_id = invoice.id
+        finally:
+            setup.close()
+
+        # -- Barrier hook: park both workers just before the invoice SELECT --
+        barrier = threading.Barrier(2)
+        thread_state = threading.local()
+
+        def sync_on_invoice_read(
+            conn, cursor, statement, parameters, context, executemany
+        ):
+            upper = statement.upper()
+            if "FROM INVOICES" not in upper or "JOIN" in upper:
+                return
+            if getattr(thread_state, "fired", False):
+                return
+            thread_state.fired = True
+            try:
+                barrier.wait(timeout=5)
+            except threading.BrokenBarrierError:
+                pass  # a worker blocked on the row lock never reaches it — fine
+
+        results = []
+
+        def worker():
+            db = SessionLocal()
+            try:
+                void_invoice(db, invoice_id, reason="race void", voided_by_id=1)
+                results.append("voided")
+            except HTTPException as exc:
+                db.rollback()
+                results.append(exc.status_code)
+            except Exception as exc:  # noqa: BLE001
+                db.rollback()
+                results.append(repr(exc))
+            finally:
+                db.close()
+
+        event.listen(engine, "before_cursor_execute", sync_on_invoice_read)
+        try:
+            t1 = threading.Thread(target=worker)
+            t2 = threading.Thread(target=worker)
+            t1.start()
+            t2.start()
+            t1.join(timeout=30)
+            t2.join(timeout=30)
+        finally:
+            event.remove(engine, "before_cursor_execute", sync_on_invoice_read)
+
+        assert not t1.is_alive(), "worker thread 1 hung (row-lock deadlock?)"
+        assert not t2.is_alive(), "worker thread 2 hung (row-lock deadlock?)"
+
+        # Exactly one worker voided; the loser hit the 400 already-voided path.
+        assert sorted(results, key=str) == [400, "voided"], (
+            f"expected one void winner and one 400 loser, got: {results}"
+        )
+
+        # And the ledger holds exactly ONE invoice_void reversal for this pair.
+        verify = SessionLocal()
+        try:
+            reversal_count = (
+                verify.query(GLJournalEntry)
+                .filter(
+                    GLJournalEntry.source_type == "invoice_void",
+                    GLJournalEntry.source_id == invoice_id,
+                )
+                .count()
+            )
+        finally:
+            verify.close()
+        assert reversal_count == 1, (
+            f"concurrent voids double-posted: {reversal_count} reversal JEs"
+        )


### PR DESCRIPTION
PR #912 was merged before its CodeRabbit round-2 fixes were pushed (the coder's test run was still grinding through the machine stall). This PR carries exactly those three staged fixes, re-tested against merged main:

1. **Concurrent-void race** ([review comment](https://github.com/BLB3DPrinting/filaops/pull/912#discussion_r3567229271)): `void_invoice` now reads the invoice under `with_for_update()` (same idiom as `payment_service._reconcile_invoice`), so two concurrent voids serialize — the second re-reads `status='voided'` and hits the existing 400 path instead of double-posting the `invoice_void` reversal. New `TestVoidInvoiceConcurrency` uses the threaded two-real-sessions + Barrier pattern from PR #907.
2. **Migration FK guard decoupled** ([review comment](https://github.com/BLB3DPrinting/filaops/pull/912#discussion_r3567229276)): the `fk_invoices_voided_by_id_users` existence check now runs independently of the column-add branch — a brownfield DB with the column but no FK heals on rerun.
3. **Test-DB FK backfill** (review nitpick): conftest's migration-102 patch backfills the FK via the `pg_constraint`-guarded `DO` block pattern, keeping the accumulated test DB schema-identical to a fresh migration.

Tests: `test_invoice_service.py` **47 passed** (incl. the new concurrency test) on merged main; ruff clean.

Refs #894, PR #912, #907 (concurrency-test pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent invoice void requests from creating duplicate reversal entries.
  * Ensured only one request can successfully void an invoice; subsequent attempts receive an already-voided response.
  * Improved database migration recovery for missing invoice audit relationships.

* **Tests**
  * Added coverage for concurrent invoice voiding and duplicate reversal prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->