### PR TITLE
fix(docker): add backend/.dockerignore to keep local files out of image layers

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,22 @@
+# Keep local environment, secrets, and user data out of image layers.
+# The Dockerfile does `COPY . .`, so anything not listed here is baked in.
+.env
+.env.*
+!.env.example
+venv/
+.venv/
+uploads/
+static/uploads/
+logs/
+*.log
+
+# Python caches and test/coverage artifacts
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Tests run from the repo checkout, not inside the image
+tests/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,22 +1,122 @@
-# Keep local environment, secrets, and user data out of image layers.
-# The Dockerfile does `COPY . .`, so anything not listed here is baked in.
-.env
-.env.*
+# COPY . . should receive only files needed by the running container.
+*
+!app/
+!app/**
+!migrations/
+!migrations/**
+!scripts/
+!scripts/**
+!alembic.ini
+!requirements.txt
+!VERSION
+
+# The opt-in test/E2E routes import tests.scenarios at runtime. Keep the
+# package boundary and scenario module, but no other test-only content.
+!tests/
+tests/**
+!tests/__init__.py
+!tests/scenarios.py
+
+# Defense in depth for sensitive or local files placed in an allowed tree.
+# Environment and credential material
+**/.env
+**/.env.*
+**/*.env
+**/*.env.*
+**/*.local
+**/secrets/
+**/secrets/**
+**/credentials/
+**/credentials/**
+**/.aws/
+**/.aws/**
+**/.azure/
+**/.azure/**
+**/.ssh/
+**/.ssh/**
+**/.config/gcloud/
+**/.config/gcloud/**
+**/*.secret
+**/*.secrets
+**/*.credential
+**/*.credentials
+**/*secret*.json
+**/*secret*.yaml
+**/*secret*.yml
+**/*credential*.json
+**/*credential*.yaml
+**/*credential*.yml
+**/service-account*.json
+**/service_account*.json
+**/application_default_credentials.json
+**/.netrc
+**/.pypirc
+
+# Private keys, certificates, and keystores
+**/*.pem
+**/*.key
+**/*.p8
+**/*.p12
+**/*.pfx
+**/*.ppk
+**/*.crt
+**/*.cer
+**/*.der
+**/*.jks
+**/*.keystore
+**/id_rsa
+**/id_dsa
+**/id_ecdsa
+**/id_ed25519
+
+# Local databases and backups/dumps. SQL source used by migrations and
+# maintained scripts is restored, then dump-like SQL names are excluded again.
+**/*.db
+**/*.db-*
+**/*.sqlite
+**/*.sqlite-*
+**/*.sqlite3
+**/*.sqlite3-*
+**/*.mdb
+**/*.accdb
+**/*.rdb
+**/*.dump
+**/*.dump.*
+**/*.backup
+**/*.backup.*
+**/*.bak
+**/*.sql
+!migrations/**/*.sql
+!scripts/**/*.sql
+**/*backup*.sql
+**/*dump*.sql
+**/*.sql.gz
+**/*.sql.bz2
+**/*.sql.xz
+
+# Generated data and developer artifacts inside allowed source directories
+**/venv/
+**/.venv/
+**/env/
+**/ENV/
+**/uploads/
+**/logs/
+**/*.log
+**/__pycache__/
+**/*.py[cod]
+**/.pytest_cache/
+**/.ruff_cache/
+**/.mypy_cache/
+**/.coverage
+**/.coverage.*
+**/htmlcov/
+**/.tox/
+**/.nox/
+**/*.tmp
+**/*.temp
+**/*~
+**/.git/
+**/.git/**
+
+# Safe example configuration is intentionally shipped for operators.
 !.env.example
-venv/
-.venv/
-uploads/
-static/uploads/
-logs/
-*.log
-
-# Python caches and test/coverage artifacts
-__pycache__/
-*.py[cod]
-.pytest_cache/
-.ruff_cache/
-.coverage
-htmlcov/
-
-# Tests run from the repo checkout, not inside the image
-tests/


### PR DESCRIPTION
## Summary

`backend/Dockerfile` uses `COPY . .`, so an unrestricted developer build context can bake local credentials, databases, user data, logs, caches, and other workstation artifacts into image layers. This change adds a restrictive `backend/.dockerignore` while preserving every file required by the running container.

Runtime files retained:

- `app/`, `migrations/`, and `scripts/`
- `alembic.ini`, `requirements.txt`, and `VERSION`
- `.env.example`
- `tests/__init__.py` and `tests/scenarios.py`, because the opt-in test/E2E routes import `tests.scenarios` at runtime

All other files under `tests/` are excluded. The parent `tests/` directory is re-included before those two files so Dockerignore negation semantics work correctly.

Sensitive and local exclusions are applied after the runtime allowlist, so matching files are still removed even if they are placed inside an allowed source tree. Covered patterns include:

- environment and local configuration files; secret, credential, cloud, and SSH credential locations
- private keys, certificates, and keystores
- local database files and SQLite sidecars
- SQL, dump, backup, and compressed-dump files (maintained SQL under `migrations/` and `scripts/` is re-included, then dump-like SQL names are excluded again)
- virtual environments, uploads, logs, Python caches, coverage output, temporary files, and VCS metadata

## Validation

- [x] Representative temporary context retained 432 runtime files and excluded 35 sensitive sentinel files.
- [x] Every existing file under `app/`, `migrations/`, and `scripts/` remained available, along with `alembic.ini`, `requirements.txt`, `VERSION`, and `.env.example`.
- [x] The filtered context contained exactly `tests/__init__.py` and `tests/scenarios.py` from the test tree.
- [x] `from tests.scenarios import SCENARIOS` succeeded from the filtered context and exposed the `basic` and `empty` scenarios.
- [x] Sentinel environment, credential, key/certificate, database, backup/dump, upload, log, cache, and temporary files were absent from the filtered context.
- [x] `git diff --check` passed, and all PR CI/CodeQL/CodeRabbit checks passed at head `24e074a652acf8b03ef25c61c26fb87fdfdf3738`.

The Docker client and Buildx are installed locally, but the Docker daemon was not running, so no local `docker build` was performed. The representative validation exercised the documented `**` matching and last-match-wins negation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker build hygiene by excluding local environment files, virtual environments, test artifacts, logs, uploads, and coverage data from build images.
  * Preserved the example environment configuration for reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
