### PR TITLE
fix(ci): prevent synthetic Review Council failures

### DIFF
--- a/.github/workflows/review-council.yml
+++ b/.github/workflows/review-council.yml
@@ -19,8 +19,6 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
     steps:
       - uses: actions/checkout@v7
@@ -28,8 +26,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Check review configuration
+        id: review_config
+        shell: bash
+        env:
+          REVIEW_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "$REVIEW_API_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout Review Council
-        if: env.ANTHROPIC_API_KEY != ''
+        if: steps.review_config.outputs.enabled == 'true'
         uses: actions/checkout@v7
         with:
           repository: Blb3D/review-council
@@ -38,62 +48,117 @@ jobs:
           persist-credentials: false
 
       - name: Run Review Council
-        if: env.ANTHROPIC_API_KEY != ''
-        shell: pwsh
+        id: review
+        if: steps.review_config.outputs.enabled == 'true'
+        shell: bash
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REVIEW_AGENTS: ${{ github.event.inputs.agents }}
+          REVIEW_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          REVIEW_EVENT_NAME: ${{ github.event_name }}
+          REVIEW_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          REVIEW_STANDARD: ${{ github.event.inputs.standard }}
         run: |
-          # Determine agents: full-review label → all 6, otherwise guardian + architect
-          $labels = '${{ join(github.event.pull_request.labels.*.name, ',') }}'
-          if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $agents = ('${{ github.event.inputs.agents }}' -split ',')
-          } elseif ($labels -match 'full-review') {
-            $agents = @('guardian','sentinel','architect','navigator','herald','operator')
+          report_path="$GITHUB_WORKSPACE/.code-conclave/reviews/conclave-results.xml"
+          rm -f "$report_path"
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+
+          set +e
+          pwsh -NoLogo -NoProfile -Command - <<'POWERSHELL'
+          $ErrorActionPreference = 'Stop'
+          $allowedAgents = @(
+            'guardian', 'sentinel', 'architect', 'navigator', 'herald', 'operator'
+          )
+          $labels = @(
+            $env:REVIEW_LABELS -split ',' |
+              ForEach-Object { $_.Trim().ToLowerInvariant() } |
+              Where-Object { $_ }
+          )
+
+          if ($env:REVIEW_EVENT_NAME -eq 'workflow_dispatch') {
+            if ([string]::IsNullOrWhiteSpace($env:REVIEW_AGENTS)) {
+              $agents = $allowedAgents
+            } else {
+              $agents = @(
+                $env:REVIEW_AGENTS -split ',' |
+                  ForEach-Object { $_.Trim().ToLowerInvariant() } |
+                  Where-Object { $_ }
+              )
+            }
+          } elseif ($labels -contains 'full-review') {
+            $agents = $allowedAgents
           } else {
-            $agents = @('guardian','architect')
+            $agents = @('guardian', 'architect')
           }
 
-          Write-Host "Running agents: $($agents -join ', ')"
+          $invalidAgents = @($agents | Where-Object { $_ -notin $allowedAgents })
+          if ($invalidAgents.Count -gt 0) {
+            throw "Unsupported Review Council agents: $($invalidAgents -join ', ')"
+          }
+          $agents = @($agents | Select-Object -Unique)
 
           $params = @{
-            Project      = '${{ github.workspace }}'
+            Project      = $env:GITHUB_WORKSPACE
             Agents       = $agents
-            OutputFormat  = 'junit'
+            OutputFormat = 'junit'
             CI           = $true
           }
 
-          # Diff-scoped review for PRs
-          $baseBranch = '${{ github.event.pull_request.base.ref }}'
+          $baseBranch = $env:REVIEW_BASE_BRANCH.Trim()
           if ($baseBranch) { $params.BaseBranch = $baseBranch }
 
-          # Compliance standard (manual dispatch only)
-          $standard = '${{ github.event.inputs.standard }}'
+          $standard = $env:REVIEW_STANDARD.Trim().ToLowerInvariant()
+          if ($standard -and $standard -notmatch '^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$') {
+            throw "Unsupported compliance standard identifier"
+          }
           if ($standard) { $params.Standard = $standard }
 
-          ./.review-council-tool/cli/ccl.ps1 @params
+          Write-Host "Running agents: $($agents -join ', ')"
+          & './.review-council-tool/cli/ccl.ps1' @params
+          POWERSHELL
+          review_exit=$?
+          set -e
+          echo "exit_code=$review_exit" >> "$GITHUB_OUTPUT"
+
+          report_valid=false
+          if [ -s "$report_path" ] && python - "$report_path" <<'PYTHON'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse(sys.argv[1]).getroot()
+          if root.tag not in {"testsuite", "testsuites"}:
+              raise SystemExit(f"unexpected JUnit root: {root.tag}")
+          PYTHON
+          then
+            report_valid=true
+          fi
+
+          verdict_exit=false
+          # Review Council reserves 0/1/2 for completed SHIP/HOLD/CONDITIONAL verdicts.
+          case "$review_exit" in
+            0|1|2) verdict_exit=true ;;
+          esac
+
+          if [ "$verdict_exit" = true ] && [ "$report_valid" = true ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Review Council did not complete with a valid, newly generated JUnit report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit "$review_exit"
         continue-on-error: true
 
       - name: Report skipped review
-        if: env.ANTHROPIC_API_KEY == ''
+        if: steps.review_config.outputs.enabled == 'false'
         shell: pwsh
         run: |
           $message = "Review Council skipped: ANTHROPIC_API_KEY is unavailable."
           Write-Host $message
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $message
 
-      - name: Detect Review Council reports
-        id: review_reports
-        if: always() && env.ANTHROPIC_API_KEY != ''
-        shell: bash
-        run: |
-          if [ -s .code-conclave/reviews/conclave-results.xml ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "Review Council did not produce a JUnit report; publishing is skipped." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready == 'true'
+        if: always() && steps.review.outputs.ready == 'true'
         with:
           files: .code-conclave/reviews/conclave-results.xml
           check_name: 'Review Council'
@@ -102,14 +167,14 @@ jobs:
 
       - name: Upload Reports
         uses: actions/upload-artifact@v6
-        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready == 'true'
+        if: always() && steps.review.outputs.ready == 'true'
         with:
           name: review-council-reports
           path: .code-conclave/reviews/
           retention-days: 30
 
       - name: Require Review Council report
-        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready != 'true'
+        if: always() && steps.review_config.outputs.enabled == 'true' && steps.review.outputs.ready != 'true'
         shell: bash
         run: |
           echo "Review Council execution did not produce the required JUnit report." >&2

--- a/.github/workflows/review-council.yml
+++ b/.github/workflows/review-council.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout Review Council
         if: env.ANTHROPIC_API_KEY != ''
@@ -34,6 +35,7 @@ jobs:
           repository: Blb3D/review-council
           path: .review-council-tool
           ref: 1d11fd72dc1fb4b29de0813f5550899e04943a74
+          persist-credentials: false
 
       - name: Run Review Council
         if: env.ANTHROPIC_API_KEY != ''
@@ -77,9 +79,21 @@ jobs:
           Write-Host $message
           Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $message
 
+      - name: Detect Review Council reports
+        id: review_reports
+        if: always() && env.ANTHROPIC_API_KEY != ''
+        shell: bash
+        run: |
+          if [ -s .code-conclave/reviews/conclave-results.xml ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Review Council did not produce a JUnit report; publishing is skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always() && env.ANTHROPIC_API_KEY != ''
+        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready == 'true'
         with:
           files: .code-conclave/reviews/conclave-results.xml
           check_name: 'Review Council'
@@ -88,8 +102,15 @@ jobs:
 
       - name: Upload Reports
         uses: actions/upload-artifact@v6
-        if: always() && env.ANTHROPIC_API_KEY != ''
+        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready == 'true'
         with:
           name: review-council-reports
           path: .code-conclave/reviews/
           retention-days: 30
+
+      - name: Require Review Council report
+        if: always() && env.ANTHROPIC_API_KEY != '' && steps.review_reports.outputs.ready != 'true'
+        shell: bash
+        run: |
+          echo "Review Council execution did not produce the required JUnit report." >&2
+          exit 1

--- a/.github/workflows/review-council.yml
+++ b/.github/workflows/review-council.yml
@@ -28,12 +28,12 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout Review Council
+        if: env.ANTHROPIC_API_KEY != ''
         uses: actions/checkout@v7
         with:
           repository: Blb3D/review-council
           path: .review-council-tool
-          # Pin to specific version for stability:
-          # ref: v1.0.0
+          ref: 1d11fd72dc1fb4b29de0813f5550899e04943a74
 
       - name: Run Review Council
         if: env.ANTHROPIC_API_KEY != ''
@@ -69,22 +69,17 @@ jobs:
           ./.review-council-tool/cli/ccl.ps1 @params
         continue-on-error: true
 
-      - name: Run Review Council (DryRun)
+      - name: Report skipped review
         if: env.ANTHROPIC_API_KEY == ''
         shell: pwsh
         run: |
-          Write-Host "No ANTHROPIC_API_KEY secret — running DryRun mode"
-          ./.review-council-tool/cli/ccl.ps1 `
-            -Project '${{ github.workspace }}' `
-            -Agent guardian `
-            -DryRun `
-            -OutputFormat junit `
-            -CI
-        continue-on-error: true
+          $message = "Review Council skipped: ANTHROPIC_API_KEY is unavailable."
+          Write-Host $message
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value $message
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+        if: always() && env.ANTHROPIC_API_KEY != ''
         with:
           files: .code-conclave/reviews/conclave-results.xml
           check_name: 'Review Council'
@@ -93,7 +88,7 @@ jobs:
 
       - name: Upload Reports
         uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && env.ANTHROPIC_API_KEY != ''
         with:
           name: review-council-reports
           path: .code-conclave/reviews/


### PR DESCRIPTION
## Summary

- skip the external Review Council checkout and execution when `ANTHROPIC_API_KEY` is unavailable
- scope the API secret only to trusted configuration detection and the review process
- pass and validate dispatch/PR inputs through step environment variables rather than interpolating them into PowerShell
- remove prior output and publish only a newly generated, valid JUnit report paired with Review Council's completed-verdict exits `0`, `1`, or `2`
- fail keyed runs that produce no trustworthy report while leaving no-key runs as an explicit clean skip
- disable persisted checkout credentials and pin `Blb3D/review-council` to immutable commit `1d11fd72dc1fb4b29de0813f5550899e04943a74`

## Root cause

Review Council DryRun output contains hardcoded sample failures. Publishing that JUnit file made skipped reviews look like real security failures on nonexistent paths.

## Validation

- YAML, Bash, and embedded PowerShell syntax checks
- workflow invariants cover secret scope, environment-safe inputs, stale-report removal, JUnit XML validation, and verdict-exit allowlisting
- pinned CLI audit confirms `0/1/2` are completed review verdicts while `10-14` are execution/provider failures
- child PowerShell exit-code propagation check
- `git diff --check`
- GitHub Actions and bot reviews on this PR are the authoritative workflow validation

Release tracker: #929

Closes #599
