### PR TITLE
fix: enforce frontend lint warning ratchet

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -144,6 +144,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
         run: cd frontend && npm ci
+      - name: Lint frontend
+        run: cd frontend && npm run lint:ci
       - name: Build frontend
         run: cd frontend && npm run build
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run frontend linting
         run: |
           cd frontend
-          npm run lint -- --max-warnings 50 || echo "Lint warnings present - not blocking during active development"
+          npm run lint:ci
 
       - name: Run frontend unit tests
         run: |

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -24,10 +24,24 @@ export default defineConfig([globalIgnores(['dist']), {
     },
   },
   rules: {
-    'no-unused-vars': ['error', {
+    'no-unused-vars': ['warn', {
       varsIgnorePattern: '^[A-Z_]',
       argsIgnorePattern: '^_',
       caughtErrorsIgnorePattern: '^_',
     }],
+    'react-hooks/set-state-in-effect': 'warn',
+    'react-hooks/immutability': 'warn',
+    'react-hooks/preserve-manual-memoization': 'warn',
+    'react-hooks/refs': 'warn',
+    'react-refresh/only-export-components': 'warn',
+  },
+}, {
+  files: ['src/**/*.{test,spec}.{js,jsx}'],
+  languageOptions: {
+    globals: {
+      ...globals.browser,
+      ...globals.node,
+      ...globals.vitest,
+    },
   },
 }, ...storybook.configs["flat/recommended"]])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "lint:ci": "eslint . --max-warnings 242",
     "preview": "vite preview",
     "test:e2e": "playwright test --project=chromium",
     "test:e2e:ui": "playwright test --ui",

--- a/frontend/src/hooks/__tests__/useActivityTokenRefresh.test.jsx
+++ b/frontend/src/hooks/__tests__/useActivityTokenRefresh.test.jsx
@@ -1,0 +1,33 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import useActivityTokenRefresh from '../useActivityTokenRefresh'
+
+describe('useActivityTokenRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-28T00:00:00Z'))
+    localStorage.setItem('adminUser', JSON.stringify({ id: 1 }))
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('initializes activity on mount so the first interval refreshes an active session', async () => {
+    renderHook(() => useActivityTokenRefresh())
+
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000)
+      await Promise.resolve()
+    })
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/v1\/auth\/refresh$/),
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    )
+  })
+})

--- a/frontend/src/hooks/useActivityTokenRefresh.js
+++ b/frontend/src/hooks/useActivityTokenRefresh.js
@@ -23,7 +23,7 @@ const INACTIVITY_TIMEOUT_MINUTES = 25;
  *   useActivityTokenRefresh(); // Call once in your app root or layout
  */
 export default function useActivityTokenRefresh() {
-  const lastActivityRef = useRef(Date.now());
+  const lastActivityRef = useRef(null);
   const isRefreshingRef = useRef(false);
 
   // Update last activity timestamp on user interaction
@@ -77,6 +77,8 @@ export default function useActivityTokenRefresh() {
   }, [refreshToken]);
 
   useEffect(() => {
+    lastActivityRef.current = Date.now();
+
     // Activity event listeners
     const events = ["mousedown", "keydown", "mousemove", "scroll", "touchstart"];
 

--- a/frontend/src/pages/admin/AdminSettings.jsx
+++ b/frontend/src/pages/admin/AdminSettings.jsx
@@ -297,7 +297,7 @@ const AdminSettings = () => {
             {settings?.has_logo ? (
               <div className="relative">
                 <img
-                  src={`${API_URL}/api/v1/settings/company/logo?t=${Date.now()}`}
+                  src={`${API_URL}/api/v1/settings/company/logo?revision=${encodeURIComponent(settings.updated_at)}`}
                   alt="Company Logo"
                   className="w-32 h-32 object-contain bg-gray-700 rounded-lg"
                 />

--- a/frontend/src/pages/admin/__tests__/AdminSettings.logo.test.jsx
+++ b/frontend/src/pages/admin/__tests__/AdminSettings.logo.test.jsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    api: {
+      get: vi.fn(),
+      patch: vi.fn(),
+      post: vi.fn(),
+      delete: vi.fn(),
+      del: vi.fn(),
+    },
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+  },
+}))
+
+vi.mock('../../../hooks/useApi', () => ({ useApi: () => mocks.api }))
+vi.mock('../../../components/Toast', () => ({
+  useToast: () => ({ success: mocks.toastSuccess, error: mocks.toastError }),
+}))
+vi.mock('../../../hooks/useVersionCheck', () => ({
+  useVersionCheck: () => ({
+    latestVersion: null,
+    installMethod: 'docker',
+    updateAvailable: false,
+    loading: false,
+    checkForUpdates: vi.fn(),
+  }),
+}))
+vi.mock('../../../utils/version', () => ({
+  getCurrentVersion: vi.fn().mockResolvedValue('4.1.0'),
+  getCurrentVersionSync: vi.fn().mockReturnValue('4.1.0'),
+  formatVersion: (version) => version,
+}))
+vi.mock('../../../contexts/LocaleContext', () => ({
+  useLocale: () => ({ updateLocaleSettings: vi.fn() }),
+}))
+vi.mock('../../../contexts/AppContext', () => ({
+  useApp: () => ({ smtpConfigured: true }),
+}))
+vi.mock('../../../components/LicenseSection', () => ({ default: () => null }))
+vi.mock('../../../components/settings/QualitySettingsSection', () => ({ default: () => null }))
+
+import AdminSettings from '../AdminSettings'
+
+const companySettings = {
+  company_name: 'FilaOps Test Farm',
+  has_logo: true,
+  updated_at: '2026-07-28T00:00:00Z',
+}
+
+let currentSettings
+
+describe('AdminSettings company logo cache revision', () => {
+  beforeEach(() => {
+    currentSettings = companySettings
+    mocks.api.get.mockReset()
+    mocks.api.get.mockImplementation((path) => {
+      if (path === '/api/v1/settings/company') return Promise.resolve(currentSettings)
+      if (path === '/api/v1/tax-rates') return Promise.resolve([])
+      return Promise.reject(new Error(`Unexpected GET ${path}`))
+    })
+    mocks.toastSuccess.mockReset()
+    mocks.toastError.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the logo URL stable across renders and revises it only after a successful replacement', async () => {
+    const failedUpload = {
+      ok: false,
+      json: vi.fn().mockResolvedValue({ detail: 'Invalid logo' }),
+    }
+    const successfulUpload = { ok: true }
+    const uploadFetch = vi.fn()
+      .mockResolvedValueOnce(failedUpload)
+      .mockResolvedValueOnce(successfulUpload)
+    vi.stubGlobal('fetch', uploadFetch)
+
+    const { container, rerender, unmount } = render(
+      <MemoryRouter>
+        <AdminSettings />
+      </MemoryRouter>,
+    )
+
+    const logo = await screen.findByAltText('Company Logo')
+    const initialUrl = logo.getAttribute('src')
+    expect(initialUrl).toMatch(
+      new RegExp(`\\?revision=${encodeURIComponent(companySettings.updated_at)}$`),
+    )
+
+    rerender(
+      <MemoryRouter>
+        <AdminSettings />
+      </MemoryRouter>,
+    )
+    expect(screen.getByAltText('Company Logo')).toHaveAttribute('src', initialUrl)
+
+    const fileInput = container.querySelector('input[type="file"]')
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['bad'], 'bad.png', { type: 'image/png' })] },
+    })
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('Invalid logo'))
+    expect(screen.getByAltText('Company Logo')).toHaveAttribute('src', initialUrl)
+
+    currentSettings = {
+      ...companySettings,
+      updated_at: '2026-07-28T00:05:00Z',
+    }
+    fireEvent.change(fileInput, {
+      target: { files: [new File(['good'], 'good.png', { type: 'image/png' })] },
+    })
+    await waitFor(() => expect(mocks.toastSuccess).toHaveBeenCalledWith('Logo uploaded successfully!'))
+    const replacedUrl = initialUrl.replace(
+      encodeURIComponent(companySettings.updated_at),
+      encodeURIComponent(currentSettings.updated_at),
+    )
+    await waitFor(() => {
+      expect(screen.getByAltText('Company Logo')).toHaveAttribute('src', replacedUrl)
+    })
+
+    unmount()
+    render(
+      <MemoryRouter>
+        <AdminSettings />
+      </MemoryRouter>,
+    )
+    expect(await screen.findByAltText('Company Logo')).toHaveAttribute('src', replacedUrl)
+  })
+})

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
-const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({


### PR DESCRIPTION
## Summary
- make frontend lint failures blocking with the approved 242-warning ratchet while keeping correctness rules at error severity
- fix the two genuine React purity findings: persistent company-logo cache revisioning and mount-time activity initialization
- scope Node/Vitest globals to unit tests and use ESM-native Vitest path resolution

The ratchet is intentionally count-based: it blocks any net warning increase from the locked baseline while existing warning debt is burned down separately.

## Related Issues
Closes #734
Release-gate work for #929

## Changes
- demote only the six approved existing-debt rules to warnings; no rule is disabled
- add `lint:ci` and run it in active `core-ci` plus the manual test workflow without a failure-swallowing fallback
- add focused regressions for logo cache persistence across remounts and activity-token initialization

## Testing
- [ ] Manual browser validation (automated regressions cover the changed behavior)
- [ ] API endpoint tested (no backend endpoint changed)
- [ ] Fresh database tested (no database change)
- [x] `npm ci`
- [x] `npm run lint` — 0 errors, 242 warnings
- [x] `npm run lint:ci` — passes at ceiling 242
- [x] `npx eslint . --max-warnings 241` — fails as expected
- [x] focused Vitest — 2 files, 2 tests passed
- [x] serial full unit suite — 68 files, 600 tests passed
- [x] `npm run build`

## Checklist
- [x] No secrets or business data committed
- [x] No PRO code in core changes
- [x] Tested on Windows (frontend-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved activity-based session token refresh timing.
  - Company logo URLs now remain stable between renders and update only after a successful upload.

- **Tests**
  - Added coverage for session token refresh behavior and logo upload outcomes.

- **Quality Improvements**
  - Added stricter frontend linting checks to automated validation.
  - Expanded React and test-environment lint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->