### PR TITLE
fix: patch root PostCSS high advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@playwright/test": "^1.57.0",
         "autoprefixer": "^10.4.22",
-        "postcss": "^8.5.12",
+        "postcss": "^8.5.18",
         "tailwindcss": "^4.1.17"
       }
     },
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -276,7 +276,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@playwright/test": "^1.57.0",
     "autoprefixer": "^10.4.22",
-    "postcss": "^8.5.12",
+    "postcss": "^8.5.18",
     "tailwindcss": "^4.1.17"
   }
 }


### PR DESCRIPTION
## Summary

- bump the root development dependency from `postcss@^8.5.12` to `postcss@^8.5.18`
- regenerate only the root lockfile entries needed for PostCSS 8.5.18, including its required compatible `nanoid` refresh

## Why

This removes the root lockfile exposure to [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), a high-severity path-traversal issue in previous source-map loading fixed in PostCSS 8.5.18.

The root package is development-only and no runtime behavior changes. This is the narrow release-stabilization remediation tracked by #929.

Base: `e973f5d7ee3670d2eaf65b2f413680c612dbe513`

## Validation

- `npm ci` - passed; install audit reported 0 vulnerabilities
- `npm ls postcss --all` - only `postcss@8.5.18` (direct and deduped under Autoprefixer)
- `npm audit --offline --audit-level=high` - 0 vulnerabilities
- PostCSS parse/process module smoke - passed on 8.5.18
- `git diff --check` - passed
- final diff scope - root `package.json` and `package-lock.json` only
