### PR TITLE
fix(deps): bump @humanfs/node to 0.16.8 (Dependabot #75)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1281,25 +1281,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }

--- a/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
+++ b/frontend/src/components/quotes/__tests__/QuoteDetailModal.test.jsx
@@ -19,7 +19,8 @@ const quote = {
   has_image: false,
   line_count: 1,
   created_at: "2026-05-21T12:00:00Z",
-  expires_at: "2026-08-19T12:00:00Z",
+  // Relative so the "still valid" fixture never silently expires.
+  expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
   sales_order_id: null,
   updated_at: "2026-05-21T12:00:00Z",
   approved_at: null,


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #75](https://github.com/BLB3DPrinting/filaops/security/dependabot/75) — GHSA-p498-v437-472g, CWE-22, CVSS 4.0 score 5.7 (medium).

`@humanfs/node` < 0.16.8 dereferences symlinks during `copy()` / `copyAll()`, so a symlink planted inside a copied source tree pulls the target file's contents from anywhere the process can read.

## Exposure in FilaOps

- Transitive **dev-only** dependency, pulled in by `eslint@9.39.5` (`^0.16.6`).
- No FilaOps code calls `@humanfs/node` directly; ESLint uses it for config-file utilities.
- Not shipped in the production bundle. Practical risk is low, but the patch is a straight semver-compatible bump so there is no reason to carry it.

## Change

Lockfile-only. No `package.json` changes.

| Package | Before | After |
|---|---|---|
| `@humanfs/node` | 0.16.7 | 0.16.8 |
| `@humanfs/core` | 0.19.1 | 0.19.2 |
| `@humanfs/types` | — | 0.15.0 (new transitive dep of 0.16.8) |

Unrelated `libc` lockfile churn from the local npm version was deliberately excluded so the diff is only the three affected entries.

## Verification

- Integrity hashes for all three packages match `npm view` registry metadata.
- 0.16.8 published 2026-04-17 by the ESLint maintainer; no install-time scripts execute from the registry tarball.
- `npm ci` succeeds; `eslint .` runs to completion against 0.16.8 (existing lint findings are unchanged and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Also in this PR: pre-existing CI time bomb

The first CI run failed in `core-frontend-unit` on `QuoteDetailModal.test.jsx` › "does not offer edit or delete actions after customer acceptance". This is unrelated to the dependency bump and reproduces on a clean `main`.

The fixture hardcoded `expires_at: "2026-08-19"`, and the modal computes `isExpired` from the real clock, so once that date passed the "Convert to Order" button disappeared and the test broke on every branch. The second commit derives `expires_at` from `Date.now()` so the fixture cannot silently expire again. Full unit suite passes locally (66 files, 598 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated quote test data to use a dynamically calculated expiration date, keeping tests reliable regardless of when they run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->