### PR TITLE
fix: contain QC photo upload paths

### DIFF
--- a/backend/app/api/v1/endpoints/qc_photos.py
+++ b/backend/app/api/v1/endpoints/qc_photos.py
@@ -47,6 +47,19 @@ def _ensure_upload_dir() -> None:
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def _resolve_local_path(file_name: str) -> str:
+    """Resolve a photo path and require it to remain inside ``UPLOAD_DIR``."""
+    upload_root = os.path.realpath(UPLOAD_DIR)
+    local_path = os.path.realpath(os.path.join(upload_root, file_name))
+    try:
+        is_within_upload_root = os.path.commonpath((upload_root, local_path)) == upload_root
+    except ValueError:
+        is_within_upload_root = False
+    if not is_within_upload_root:
+        raise HTTPException(status_code=400, detail="Invalid photo path")
+    return local_path
+
+
 def _safe_filename(original: str, inspection_id: int) -> str:
     """Unique on-disk name: qc<inspection>_<timestamp>_<rand>.<ext>."""
     ext = os.path.splitext(original)[1].lower() or ".jpg"
@@ -152,7 +165,7 @@ async def upload_photo(
     )
     safe_name = _safe_filename(original, inspection_id)
     _ensure_upload_dir()
-    local_path = os.path.join(UPLOAD_DIR, safe_name)
+    local_path = _resolve_local_path(safe_name)
     # Write the blob and the row together: if the commit fails, remove the file
     # we just wrote so it can't orphan under uploads/qc_photos.
     try:

--- a/backend/tests/test_qc_photos.py
+++ b/backend/tests/test_qc_photos.py
@@ -90,6 +90,30 @@ class TestQCPhotos:
         )
         assert r.status_code == 413
 
+    def test_upload_rejects_path_outside_upload_root(
+        self,
+        client,
+        db,
+        photo_dir,
+        monkeypatch,
+        make_product,
+        make_production_order,
+    ):
+        """A filename regression must not let an upload escape its storage root."""
+        insp = _make_inspection(db, make_product, make_production_order)
+        outside_path = photo_dir.parent / "escaped-qc-photo.png"
+        monkeypatch.setattr(
+            "app.api.v1.endpoints.qc_photos._safe_filename",
+            lambda _original, _inspection_id: "../escaped-qc-photo.png",
+        )
+
+        r = client.post(
+            f"{BASE}/{insp.id}/photos",
+            files={"file": ("evidence.png", IMG, "image/png")},
+        )
+
+        assert (r.status_code, outside_path.exists()) == (400, False)
+
     def test_rejects_overlong_caption(
         self, client, db, photo_dir, make_product, make_production_order
     ):


### PR DESCRIPTION
## Summary

- Resolve QC photo storage paths before filesystem access.
- Reject any generated path that escapes the configured QC upload directory.
- Add a regression test that proves an escape attempt returns 400 and creates no outside file.

## Related Issues

- Code scanning alerts 28-30 (`py/path-injection`)
- Unrelated persistent local test-database drift is tracked in #971.

## Changes

- Add `_resolve_local_path()` with `realpath` normalization and upload-root containment enforcement.
- Use the validated path for upload writes and rollback cleanup.
- Add endpoint-level fault-injection coverage for a generated traversal path.

## Testing

- [ ] Manual browser validation (eyes and mouse)
- [x] API endpoint tested
- [ ] Fresh database tested (CI pending)

Local results:

- `pytest tests/test_qc_photos.py`: 10 passed
- Ruff: passed
- Python compileall: passed
- Guardrail/workflow tests: 10 passed
- Full backend run: 6,396 passed, 5 skipped, 20 unrelated order-import failures caused by the persistent local `filaops_test` schema retaining `sales_orders.unit_price NOT NULL`; tracked in #971.

## Checklist

- [x] No secrets or business data committed
- [x] No PRO code in core changes
- [x] Tested on Windows (if backend/seed changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved photo upload security by preventing files from being written outside the configured upload directory.
  - Invalid photo paths now return a clear error response instead of allowing unsafe file placement.

- **Tests**
  - Added coverage confirming path traversal attempts are rejected and do not create files outside the upload directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->